### PR TITLE
Add minimal multi-agent analytics skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # GraphMind
-Multi-Agent Analyst for Your Data Graph
+
+GraphMind is a simple prototype of a multi-agent analyst for your data graph. It
+allows you to ingest a CSV file, clean it, generate basic statistics and a chart,
+then output an executive style summary.
+
+## Requirements
+
+- Python 3.8+
+- `pip install pandas plotly`
+
+## Running locally
+
+1. Install the requirements:
+
+   ```bash
+   pip install pandas plotly
+   ```
+
+2. Execute the pipeline with a CSV file:
+
+   ```bash
+   python main.py path/to/your/data.csv
+   ```
+
+This runs entirely on your local machine and should work on most laptops,
+including a Lenovo P52. No GPU is required.

--- a/agents/analyst.py
+++ b/agents/analyst.py
@@ -1,0 +1,7 @@
+import pandas as pd
+
+class Analyst:
+    """Find basic insights from the data."""
+
+    def describe(self, df: pd.DataFrame) -> pd.DataFrame:
+        return df.describe()

--- a/agents/chartmaster.py
+++ b/agents/chartmaster.py
@@ -1,0 +1,9 @@
+import plotly.express as px
+import pandas as pd
+
+class ChartMaster:
+    """Create basic charts using Plotly."""
+
+    def generate_scatter(self, df: pd.DataFrame, x: str, y: str):
+        fig = px.scatter(df, x=x, y=y)
+        return fig.to_dict()

--- a/agents/cleaner.py
+++ b/agents/cleaner.py
@@ -1,0 +1,10 @@
+import pandas as pd
+
+class Cleaner:
+    """Basic data cleaning operations."""
+
+    def clean(self, df: pd.DataFrame) -> pd.DataFrame:
+        cleaned = df.copy()
+        cleaned.drop_duplicates(inplace=True)
+        cleaned.fillna(method='ffill', inplace=True)
+        return cleaned

--- a/agents/ingestor.py
+++ b/agents/ingestor.py
@@ -1,0 +1,11 @@
+import pandas as pd
+from pathlib import Path
+
+class Ingestor:
+    """Load data from a CSV file."""
+
+    def load_csv(self, path: str) -> pd.DataFrame:
+        file_path = Path(path)
+        if not file_path.exists():
+            raise FileNotFoundError(f"File {path} not found")
+        return pd.read_csv(file_path)

--- a/agents/reporter.py
+++ b/agents/reporter.py
@@ -1,0 +1,11 @@
+import pandas as pd
+
+class Reporter:
+    """Generate a simple textual report from stats."""
+
+    def summarize(self, stats: pd.DataFrame) -> str:
+        summary_lines = [
+            "Data Summary:",
+            stats.to_string(),
+        ]
+        return "\n".join(summary_lines)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,31 @@
+import sys
+from agents.ingestor import Ingestor
+from agents.cleaner import Cleaner
+from agents.analyst import Analyst
+from agents.chartmaster import ChartMaster
+from agents.reporter import Reporter
+
+
+def main(csv_path: str):
+    ingestor = Ingestor()
+    cleaner = Cleaner()
+    analyst = Analyst()
+    chartmaster = ChartMaster()
+    reporter = Reporter()
+
+    df = ingestor.load_csv(csv_path)
+    cleaned = cleaner.clean(df)
+    stats = analyst.describe(cleaned)
+    chart = chartmaster.generate_scatter(cleaned, cleaned.columns[0], cleaned.columns[1])
+    report = reporter.summarize(stats)
+
+    print(report)
+    print("\nChart spec:")
+    print(chart)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python main.py <csv_path>")
+        sys.exit(1)
+    main(sys.argv[1])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+plotly


### PR DESCRIPTION
## Summary
- flesh out README with local run instructions
- add basic agent modules for ingesting data, cleaning, analyzing, charting and reporting
- provide a simple `main.py` orchestrator
- list requirements

## Testing
- `python -m py_compile $(find . -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6848fde7383c83278a41b9f8ebd2ad73