### PR TITLE
Fix histogram template interpolation

### DIFF
--- a/agents/chartmaster.py
+++ b/agents/chartmaster.py
@@ -149,7 +149,7 @@ class ChartMaster:
             .data(bins)
             .enter().append('rect')
             .attr('x', 1)
-            .attr('transform', d => `translate(${x(d.x0)},${y(d.length)})`)
+            .attr('transform', d => `translate(${{x(d.x0)}},${{y(d.length)}})`)
             .attr('width', d => Math.max(0, x(d.x1) - x(d.x0) - 1))
             .attr('height', d => height - y(d.length))
             .attr('fill', '#636efa');


### PR DESCRIPTION
## Summary
- escape curly braces in histogram template

## Testing
- `python3 -m py_compile \
  `git ls-files '*.py'`
- `python3 main.py test.csv` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684907e9647c83279156a46fa63550d0